### PR TITLE
Housing bulk furnish

### DIFF
--- a/src/bot/commands/help/help.ts
+++ b/src/bot/commands/help/help.ts
@@ -116,6 +116,7 @@ const embeds: {
 					"`/house collect` - Collect rent from leased homes, once an hour",
 					"`/house renovate <id>` - Increase the quality of a house, for a price",
 					"`/house furnish <house id> <furniture id>` - Add furniture.",
+					"`/house bulk_furnish <house id> <start id> <end id> - Add unassigned furniture with an id in the range from <start> to <end>.",
 				].join("\n"),
 			},
 		),

--- a/src/bot/commands/help/help.ts
+++ b/src/bot/commands/help/help.ts
@@ -116,7 +116,7 @@ const embeds: {
 					"`/house collect` - Collect rent from leased homes, once an hour",
 					"`/house renovate <id>` - Increase the quality of a house, for a price",
 					"`/house furnish <house id> <furniture id>` - Add furniture.",
-					"`/house bulk_furnish <house id> <start id> <end id> - Add unassigned furniture with an id in the range from <start> to <end>.",
+					"`/house bulk_furnish <house id> <start id> <end id>` - Add unassigned furniture with an id in the range from <start> to <end>.",
 				].join("\n"),
 			},
 		),

--- a/src/bot/commands/housing/house.ts
+++ b/src/bot/commands/housing/house.ts
@@ -140,7 +140,7 @@ export const house: LifebotCommand = {
 		const subCommand = interaction.options.getSubcommand(true);
 
 		try {
-			houseCommands[subCommand](props);
+			await houseCommands[subCommand](props);
 		} catch (e) {
 			console.error(e);
 			interaction.reply("Error executing this command, try again later.");

--- a/src/bot/commands/housing/house.ts
+++ b/src/bot/commands/housing/house.ts
@@ -14,6 +14,7 @@ import { info } from "./house/info";
 import { lease } from "./house/lease";
 import { renovate } from "./house/renovate";
 import { sell } from "./house/sell";
+import { bulkFurnish } from "./house/bulkFurnish";
 
 const houseCommands: {
 	[key: string]: LifebotCommandHandler;
@@ -25,6 +26,7 @@ const houseCommands: {
 	renovate,
 	collect,
 	furnish,
+	bulk_furnish: bulkFurnish,
 };
 
 export const house: LifebotCommand = {
@@ -105,6 +107,31 @@ export const house: LifebotCommand = {
 					new SlashCommandIntegerOption()
 						.setName("furniture")
 						.setDescription("The furniture's id")
+						.setRequired(true),
+				),
+		)
+		.addSubcommand(
+			new SlashCommandSubcommandBuilder()
+				.setName("bulk_furnish")
+				.setDescription(
+					"Place unassigned furniture you own with id from <start> to <end> in a house",
+				)
+				.addIntegerOption(
+					new SlashCommandIntegerOption()
+						.setName("house")
+						.setDescription("The id of the house")
+						.setRequired(true),
+				)
+				.addIntegerOption(
+					new SlashCommandIntegerOption()
+						.setName("start")
+						.setDescription("Add unassigned furniture from this id")
+						.setRequired(true),
+				)
+				.addIntegerOption(
+					new SlashCommandIntegerOption()
+						.setName("end")
+						.setDescription("Add unassigned furniture to this id")
 						.setRequired(true),
 				),
 		),

--- a/src/bot/commands/housing/house.ts
+++ b/src/bot/commands/housing/house.ts
@@ -7,6 +7,7 @@ import type {
 	LifebotCommand,
 	LifebotCommandHandler,
 } from "../../types/commandTypes";
+import { bulkFurnish } from "./house/bulkFurnish";
 import { buy } from "./house/buy";
 import { collect } from "./house/collect";
 import { furnish } from "./house/furnish";
@@ -14,7 +15,6 @@ import { info } from "./house/info";
 import { lease } from "./house/lease";
 import { renovate } from "./house/renovate";
 import { sell } from "./house/sell";
-import { bulkFurnish } from "./house/bulkFurnish";
 
 const houseCommands: {
 	[key: string]: LifebotCommandHandler;

--- a/src/bot/commands/housing/house/bulkFurnish.ts
+++ b/src/bot/commands/housing/house/bulkFurnish.ts
@@ -1,0 +1,120 @@
+import { and, count, eq, gte, isNull, lte } from "drizzle-orm";
+import { db } from "../../../../db";
+import { furnitureTable, housesTable } from "../../../../db/schema";
+import type { LifebotCommandHandler } from "../../../types/commandTypes";
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	EmbedBuilder,
+} from "discord.js";
+import { noHouseFoundEmbed } from "./util/noHouseEmbed";
+import { Color } from "../../../utils/colors";
+import { fullFurnitureValueRecalc } from "./util/fullFurnitureRecalc";
+
+export const bulkFurnish: LifebotCommandHandler = async ({
+	user,
+	interaction,
+}) => {
+	const houseId = interaction.options.getInteger("house", true);
+	const startId = interaction.options.getInteger("start", true);
+	const endId = interaction.options.getInteger("end", true);
+
+	const houseList = await db
+		.select()
+		.from(housesTable)
+		.where(
+			and(eq(housesTable.ownerId, user.userId), eq(housesTable.id, houseId)),
+		);
+
+	if (houseList.length < 1) {
+		return interaction.reply({
+			embeds: [noHouseFoundEmbed],
+		});
+	}
+
+	const house = houseList[0];
+
+	const whereCondition = and(
+		eq(furnitureTable.ownerId, user.userId),
+		isNull(furnitureTable.houseId),
+		lte(furnitureTable.id, endId),
+		gte(furnitureTable.id, startId),
+	);
+
+	const furnitureItems = await db
+		.select({
+			count: count(),
+		})
+		.from(furnitureTable)
+		.where(whereCondition);
+
+	const itemCount = furnitureItems[0].count;
+
+	const confirmEmbed = new EmbedBuilder()
+		.setTitle("Are you sure?")
+		.setDescription(
+			`This will assign ${itemCount} furniture items to house with id \`${houseId}\`.`,
+		)
+		.setColor(Color.BLUE)
+		.setFooter({
+			text: "Expires in 60 seconds.",
+		});
+
+	const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
+		new ButtonBuilder()
+			.setLabel("Confirm")
+			.setCustomId("c")
+			.setStyle(ButtonStyle.Danger),
+	);
+
+	const reply = await interaction.reply({
+		embeds: [confirmEmbed],
+		components: [buttons],
+	});
+
+	reply
+		.awaitMessageComponent({
+			time: 60_000,
+			filter: (i) => i.user.id === user.userId,
+		})
+		.then(async (newI) => {
+			try {
+				const assignedItems = await db
+					.update(furnitureTable)
+					.set({
+						houseId: house.id,
+					})
+					.where(whereCondition)
+					.returning();
+
+				const itemsNames = assignedItems
+					.map((item) => `${item.material} ${item.type}`)
+					.join("\n");
+
+				const newScore = await fullFurnitureValueRecalc(house.id);
+
+				const updatedEmbed = new EmbedBuilder()
+					.setColor(Color.BLUE)
+					.setTitle("House furnished!")
+					.setDescription(`New furniture score: ${newScore.toFixed(2)}/100`)
+					.addFields({
+						name: "Added the following items: ",
+						value: itemsNames,
+					});
+
+				await newI.reply({
+					embeds: [updatedEmbed],
+				});
+			} catch (e) {
+				console.warn(e);
+				newI.reply("Something went wrong...");
+			}
+		})
+		.catch((e) => {
+			reply.edit({
+				embeds: [confirmEmbed.setTitle("Expired").setColor(Color.RED)],
+				components: [],
+			});
+		});
+};

--- a/src/bot/commands/housing/house/bulkFurnish.ts
+++ b/src/bot/commands/housing/house/bulkFurnish.ts
@@ -1,16 +1,16 @@
-import { and, count, eq, gte, isNull, lte } from "drizzle-orm";
-import { db } from "../../../../db";
-import { furnitureTable, housesTable } from "../../../../db/schema";
-import type { LifebotCommandHandler } from "../../../types/commandTypes";
 import {
 	ActionRowBuilder,
 	ButtonBuilder,
 	ButtonStyle,
 	EmbedBuilder,
 } from "discord.js";
-import { noHouseFoundEmbed } from "./util/noHouseEmbed";
+import { and, count, eq, gte, isNull, lte } from "drizzle-orm";
+import { db } from "../../../../db";
+import { furnitureTable, housesTable } from "../../../../db/schema";
+import type { LifebotCommandHandler } from "../../../types/commandTypes";
 import { Color } from "../../../utils/colors";
 import { fullFurnitureValueRecalc } from "./util/fullFurnitureRecalc";
+import { noHouseFoundEmbed } from "./util/noHouseEmbed";
 
 export const bulkFurnish: LifebotCommandHandler = async ({
 	user,

--- a/src/bot/commands/housing/house/bulkFurnish.ts
+++ b/src/bot/commands/housing/house/bulkFurnish.ts
@@ -20,6 +20,16 @@ export const bulkFurnish: LifebotCommandHandler = async ({
 	const startId = interaction.options.getInteger("start", true);
 	const endId = interaction.options.getInteger("end", true);
 
+	if (endId > startId) {
+		return interaction.reply({
+			embeds: [
+				new EmbedBuilder()
+					.setColor(Color.RED)
+					.setDescription("End id must not be greater than start id"),
+			],
+		});
+	}
+
 	const houseList = await db
 		.select()
 		.from(housesTable)

--- a/src/bot/commands/housing/house/furnish.ts
+++ b/src/bot/commands/housing/house/furnish.ts
@@ -9,6 +9,7 @@ import {
 	type FurnitureItem,
 	calculateFurnitureScore,
 } from "../furniture/furnitureCalculations";
+import { fullFurnitureValueRecalc } from "./util/fullFurnitureRecalc";
 
 const noHouseEmbed = new EmbedBuilder()
 	.setTitle("No house")
@@ -87,22 +88,8 @@ export const furnish: LifebotCommandHandler = async ({ interaction, user }) => {
 		.where(eq(furnitureTable.id, furnitureItem.id));
 
 	// now we can change the house furniture score
-	// This is overly complex to deal with possible changes down the line. Rather than just increment the score, we perform a full recalculation
 
-	const allFurniture = await db
-		.select()
-		.from(furnitureTable)
-		.where(eq(furnitureTable.houseId, house.id));
-	let score = 0;
-	for (const item of allFurniture) {
-		score += calculateFurnitureScore(item as FurnitureItem);
-	}
-	await db
-		.update(housesTable)
-		.set({
-			furnitureScore: Math.min(100, score),
-		})
-		.where(eq(housesTable.id, house.id));
+	await fullFurnitureValueRecalc(house.id);
 
 	const successEmbed = new EmbedBuilder()
 		.setTitle("Furniture Assigned")

--- a/src/bot/commands/housing/house/furnish.ts
+++ b/src/bot/commands/housing/house/furnish.ts
@@ -34,7 +34,7 @@ export const furnish: LifebotCommandHandler = async ({ interaction, user }) => {
 	const houseId = interaction.options.getInteger("house", true);
 	const furnitureId = interaction.options.getInteger("furniture", true);
 
-	const houseListPromoise = db
+	const houseListPromise = db
 		.select()
 		.from(housesTable)
 		.where(
@@ -51,7 +51,7 @@ export const furnish: LifebotCommandHandler = async ({ interaction, user }) => {
 			),
 		);
 
-	const houseList = await houseListPromoise;
+	const houseList = await houseListPromise;
 	const furnitureList = await furnitureListPromise;
 
 	if (houseList.length < 1) {
@@ -89,12 +89,12 @@ export const furnish: LifebotCommandHandler = async ({ interaction, user }) => {
 
 	// now we can change the house furniture score
 
-	await fullFurnitureValueRecalc(house.id);
+	const newScore = await fullFurnitureValueRecalc(house.id);
 
 	const successEmbed = new EmbedBuilder()
 		.setTitle("Furniture Assigned")
 		.setDescription(
-			`You have added one ${furnitureItem.material} ${furnitureItem.type} to house ${houseId}`,
+			`You have added one ${furnitureItem.material} ${furnitureItem.type} to house ${houseId}\nNew furniture score: ${newScore.toFixed(2)}/100`,
 		)
 		.setColor(Color.BLUE);
 

--- a/src/bot/commands/housing/house/util/fullFurnitureRecalc.ts
+++ b/src/bot/commands/housing/house/util/fullFurnitureRecalc.ts
@@ -7,23 +7,28 @@ import {
 } from "../../furniture/furnitureCalculations";
 
 export const fullFurnitureValueRecalc = async (houseId: number) => {
-	const allFurniture = await db
-		.select()
-		.from(furnitureTable)
-		.where(eq(furnitureTable.houseId, houseId));
-	let score = 0;
-	for (const item of allFurniture) {
-		score += calculateFurnitureScore(item as FurnitureItem);
+	try {
+		const allFurniture = await db
+			.select()
+			.from(furnitureTable)
+			.where(eq(furnitureTable.houseId, houseId));
+		let score = 0;
+		for (const item of allFurniture) {
+			score += calculateFurnitureScore(item as FurnitureItem);
+		}
+
+		score = Math.min(100, score);
+
+		await db
+			.update(housesTable)
+			.set({
+				furnitureScore: score,
+			})
+			.where(eq(housesTable.id, houseId));
+
+		return score;
+	} catch (e) {
+		console.error(e);
+		throw e;
 	}
-
-	score = Math.min(100, score);
-
-	await db
-		.update(housesTable)
-		.set({
-			furnitureScore: score,
-		})
-		.where(eq(housesTable.id, houseId));
-
-	return score;
 };

--- a/src/bot/commands/housing/house/util/fullFurnitureRecalc.ts
+++ b/src/bot/commands/housing/house/util/fullFurnitureRecalc.ts
@@ -1,0 +1,29 @@
+import { eq } from "drizzle-orm";
+import { db } from "../../../../../db";
+import { furnitureTable, housesTable } from "../../../../../db/schema";
+import {
+	calculateFurnitureScore,
+	type FurnitureItem,
+} from "../../furniture/furnitureCalculations";
+
+export const fullFurnitureValueRecalc = async (houseId: number) => {
+	const allFurniture = await db
+		.select()
+		.from(furnitureTable)
+		.where(eq(furnitureTable.houseId, houseId));
+	let score = 0;
+	for (const item of allFurniture) {
+		score += calculateFurnitureScore(item as FurnitureItem);
+	}
+
+	score = Math.min(100, score);
+
+	await db
+		.update(housesTable)
+		.set({
+			furnitureScore: score,
+		})
+		.where(eq(housesTable.id, houseId));
+
+	return score;
+};

--- a/src/bot/commands/housing/house/util/fullFurnitureRecalc.ts
+++ b/src/bot/commands/housing/house/util/fullFurnitureRecalc.ts
@@ -2,8 +2,8 @@ import { eq } from "drizzle-orm";
 import { db } from "../../../../../db";
 import { furnitureTable, housesTable } from "../../../../../db/schema";
 import {
-	calculateFurnitureScore,
 	type FurnitureItem,
+	calculateFurnitureScore,
 } from "../../furniture/furnitureCalculations";
 
 export const fullFurnitureValueRecalc = async (houseId: number) => {


### PR DESCRIPTION
Adds `/housing bulk_furnish`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new subcommand `/house bulk_furnish <house id> <start id> <end id>` for bulk assigning unassigned furniture items to a specified house.

- **Refactor**
  - Streamlined the process of updating a house’s furniture score for improved efficiency.

- **Documentation**
  - Updated help command to include description for the new `/house bulk_furnish` subcommand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->